### PR TITLE
Review code

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,16 @@
+{
+  "plugins": ["prettier-plugin-solidity"],
+  "overrides": [
+    {
+      "files": "*.sol",
+      "options": {
+        "parser": "solidity-parse",
+        "printWidth": 80,
+        "tabWidth": 2,
+        "useTabs": false,
+        "singleQuote": false,
+        "bracketSpacing": false
+      }
+    }
+  ]
+}

--- a/src/Ad.sol
+++ b/src/Ad.sol
@@ -5,7 +5,7 @@ import {Harberger, Perwei} from "./Harberger.sol";
 import {ReentrancyGuard} from "./ReentrancyGuard.sol";
 
 interface IERC20 {
-    function mint(address to, uint256 value) external;
+  function mint(address to, uint256 value) external;
 }
 
 address constant treasury = 0x1337E2624ffEC537087c6774e9A18031CFEAf0a9;
@@ -22,86 +22,86 @@ uint256 constant denominator = 2629742;
 // case of an update, by e.g. allowing an admit to call a function that sends
 // the leftover collateral to the lastController.
 contract Ad is ReentrancyGuard {
-    error ErrValue();
-    error ErrUnauthorized();
-    error ErrCall();
+  error ErrValue();
+  error ErrUnauthorized();
+  error ErrCall();
 
-    string public title;
-    string public href;
+  string public title;
+  string public href;
 
-    address public token;
+  address public token;
 
-    address public controller;
-    uint256 public collateral;
-    uint256 public timestamp;
+  address public controller;
+  uint256 public collateral;
+  uint256 public timestamp;
 
-    constructor(address _token) {
-        token = _token;
+  constructor(address _token) {
+    token = _token;
+  }
+
+  function price() public view returns (uint256 nextPrice, uint256 taxes) {
+    return
+      Harberger.getNextPrice(
+        Perwei(numerator, denominator),
+        block.timestamp - timestamp,
+        collateral
+      );
+  }
+
+  function set(
+    string calldata _title,
+    string calldata _href
+  ) external payable nonReentrant {
+    if (controller == address(0)) {
+      title = _title;
+      href = _href;
+      controller = msg.sender;
+      collateral = msg.value;
+      timestamp = block.timestamp;
+    } else {
+      // NOTE on the calculation of the markup: The term "markup" refers to the
+      // buyer premium, which is the difference between the last price
+      // (nextPrice) and the new price (msg.value).
+      //
+      // In this contract, the markup is divided by two for two reasons:
+      //
+      // 1. Half is sent to the token contract to reward the previous ad owner.
+      // 2. The other half ensures there is enough collateral to cover the tax
+      // obligations.
+      //
+      //
+      // Therefore, `msg.value` must be at least `nextPrice + 2 Wei`:
+      //
+      // - 1 Wei for the premium sent to the token contract.
+      // - 1 Wei to maintain sufficient collateral for taxation.
+      //
+      // This setup ensures both incentive alignment and compliance with tax
+      // obligations.
+      (uint256 nextPrice, uint256 taxes) = price();
+      if (msg.value < nextPrice + 2) {
+        revert ErrValue();
+      }
+
+      uint256 difference = msg.value - nextPrice;
+      uint256 markup = difference / 2;
+      uint256 timeDifference = block.timestamp - timestamp;
+
+      address lastController = controller;
+      title = _title;
+      href = _href;
+      controller = msg.sender;
+      collateral = msg.value - markup;
+      timestamp = block.timestamp;
+
+      (bool treasurySuccess, ) = treasury.call{value: taxes}("");
+      (bool tokenSuccess, ) = token.call{value: markup}("");
+      (bool lastSuccess, ) = lastController.call{value: nextPrice}("");
+
+      if (!treasurySuccess || !tokenSuccess || !lastSuccess) {
+        revert ErrCall();
+      }
+
+      IERC20(token).mint(lastController, timeDifference);
     }
-
-    function price() public view returns (uint256 nextPrice, uint256 taxes) {
-        return
-            Harberger.getNextPrice(
-                Perwei(numerator, denominator),
-                block.timestamp - timestamp,
-                collateral
-            );
-    }
-
-    function set(
-        string calldata _title,
-        string calldata _href
-    ) external payable nonReentrant {
-        if (controller == address(0)) {
-            title = _title;
-            href = _href;
-            controller = msg.sender;
-            collateral = msg.value;
-            timestamp = block.timestamp;
-        } else {
-            // NOTE on the calculation of the markup: The term "markup" refers to the
-            // buyer premium, which is the difference between the last price
-            // (nextPrice) and the new price (msg.value).
-            //
-            // In this contract, the markup is divided by two for two reasons:
-            //
-            // 1. Half is sent to the token contract to reward the previous ad owner.
-            // 2. The other half ensures there is enough collateral to cover the tax
-            // obligations.
-            //
-            //
-            // Therefore, `msg.value` must be at least `nextPrice + 2 Wei`:
-            //
-            // - 1 Wei for the premium sent to the token contract.
-            // - 1 Wei to maintain sufficient collateral for taxation.
-            //
-            // This setup ensures both incentive alignment and compliance with tax
-            // obligations.
-            (uint256 nextPrice, uint256 taxes) = price();
-            if (msg.value < nextPrice + 2) {
-                revert ErrValue();
-            }
-
-            uint256 difference = msg.value - nextPrice;
-            uint256 markup = difference / 2;
-            uint256 timeDifference = block.timestamp - timestamp;
-
-            address lastController = controller;
-            title = _title;
-            href = _href;
-            controller = msg.sender;
-            collateral = msg.value - markup;
-            timestamp = block.timestamp;
-
-            (bool treasurySuccess, ) = treasury.call{value: taxes}("");
-            (bool tokenSuccess, ) = token.call{value: markup}("");
-            (bool lastSuccess, ) = lastController.call{value: nextPrice}("");
-
-            if (!treasurySuccess || !tokenSuccess || !lastSuccess) {
-                revert ErrCall();
-            }
-
-            IERC20(token).mint(lastController, timeDifference);
-        }
-    }
+  }
 }

--- a/src/Ad.sol
+++ b/src/Ad.sol
@@ -1,104 +1,107 @@
 /// SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.13;
 
-import { Harberger, Perwei } from "./Harberger.sol";
-import { ReentrancyGuard } from "./ReentrancyGuard.sol";
+import {Harberger, Perwei} from "./Harberger.sol";
+import {ReentrancyGuard} from "./ReentrancyGuard.sol";
 
 interface IERC20 {
-  function mint(address to, uint256 value) external;
+    function mint(address to, uint256 value) external;
 }
 
 address constant treasury = 0x1337E2624ffEC537087c6774e9A18031CFEAf0a9;
 // NOTE: The tax rate is 1/2629742 per second. The denominator (2629743) is
-// seconds in a month. 
+// seconds in a month.
 // 1 month (avg. 30.44 days) = 2_629_743
 // We subtract a second to have an even number.
 // Practically, it means that a self-assessed key worth 1
 // ether will accumulate a tax obligation of 1 ether/month.
-uint256 constant numerator    = 1;
-uint256 constant denominator  = 2629742;
+uint256 constant numerator = 1;
+uint256 constant denominator = 2629742;
+
 // TODO: Add a function that allows to shut down this contract gracefully in
 // case of an update, by e.g. allowing an admit to call a function that sends
 // the leftover collateral to the lastController.
 contract Ad is ReentrancyGuard {
-  error ErrValue();
-  error ErrUnauthorized();
-  error ErrCall();
+    error ErrValue();
+    error ErrUnauthorized();
+    error ErrCall();
 
-  string public title;
-  string public href;
+    string public title;
+    string public href;
 
-  address public token;
+    address public token;
 
-  address public controller;
-  uint256 public collateral;
-  uint256 public timestamp;
+    address public controller;
+    uint256 public collateral;
+    uint256 public timestamp;
 
-  constructor(address _token) {
-    token = _token;
-  }
-
-  function price() public view returns (uint256 nextPrice, uint256 taxes) {
-    return Harberger.getNextPrice(
-      Perwei(numerator, denominator),
-      block.timestamp - timestamp,
-      collateral
-    );
-  }
-
-  function set(
-    string calldata _title,
-    string calldata _href
-  ) nonReentrant external payable {
-    if (controller == address(0)) {
-      title = _title;
-      href = _href;
-      controller = msg.sender;
-      collateral = msg.value;
-      timestamp = block.timestamp;
-    } else {
-      // NOTE on the calculation of the markup: The term "markup" refers to the
-      // buyer premium, which is the difference between the last price
-      // (nextPrice) and the new price (msg.value).
-      //
-      // In this contract, the markup is divided by two for two reasons:
-      //
-      // 1. Half is sent to the token contract to reward the previous ad owner.
-      // 2. The other half ensures there is enough collateral to cover the tax
-      // obligations.
-      //
-      //
-      // Therefore, `msg.value` must be at least `nextPrice + 2 Wei`:
-      //
-      // - 1 Wei for the premium sent to the token contract.
-      // - 1 Wei to maintain sufficient collateral for taxation.
-      //
-      // This setup ensures both incentive alignment and compliance with tax
-      // obligations.
-      (uint256 nextPrice, uint256 taxes) = price();
-      if (msg.value < nextPrice+2) {
-        revert ErrValue();
-      }
-
-      uint256 difference = msg.value-nextPrice;
-      uint256 markup = difference/2;
-      uint256 timeDifference = block.timestamp - timestamp;
-
-      address lastController = controller;
-      title = _title;
-      href = _href;
-      controller = msg.sender;
-      collateral = msg.value-markup;
-      timestamp = block.timestamp;
-
-      (bool treasurySuccess,) = treasury.call{value: taxes}("");
-      (bool tokenSuccess,) = token.call{value: markup}("");
-      if (!treasurySuccess || !tokenSuccess) {
-        revert ErrCall();
-      }
-      lastController.call{value: nextPrice}("");
-
-      IERC20(token).mint(lastController, timeDifference);
+    constructor(address _token) {
+        token = _token;
     }
-  }
+
+    function price() public view returns (uint256 nextPrice, uint256 taxes) {
+        return
+            Harberger.getNextPrice(
+                Perwei(numerator, denominator),
+                block.timestamp - timestamp,
+                collateral
+            );
+    }
+
+    function set(
+        string calldata _title,
+        string calldata _href
+    ) external payable nonReentrant {
+        if (controller == address(0)) {
+            title = _title;
+            href = _href;
+            controller = msg.sender;
+            collateral = msg.value;
+            timestamp = block.timestamp;
+        } else {
+            // NOTE on the calculation of the markup: The term "markup" refers to the
+            // buyer premium, which is the difference between the last price
+            // (nextPrice) and the new price (msg.value).
+            //
+            // In this contract, the markup is divided by two for two reasons:
+            //
+            // 1. Half is sent to the token contract to reward the previous ad owner.
+            // 2. The other half ensures there is enough collateral to cover the tax
+            // obligations.
+            //
+            //
+            // Therefore, `msg.value` must be at least `nextPrice + 2 Wei`:
+            //
+            // - 1 Wei for the premium sent to the token contract.
+            // - 1 Wei to maintain sufficient collateral for taxation.
+            //
+            // This setup ensures both incentive alignment and compliance with tax
+            // obligations.
+            (uint256 nextPrice, uint256 taxes) = price();
+            if (msg.value < nextPrice + 2) {
+                revert ErrValue();
+            }
+
+            uint256 difference = msg.value - nextPrice;
+            uint256 markup = difference / 2;
+            uint256 timeDifference = block.timestamp - timestamp;
+
+            address lastController = controller;
+            title = _title;
+            href = _href;
+            controller = msg.sender;
+            collateral = msg.value - markup;
+            timestamp = block.timestamp;
+
+            (bool treasurySuccess, ) = treasury.call{value: taxes}("");
+            (bool tokenSuccess, ) = token.call{value: markup}("");
+            (bool lastSuccess, ) = lastController.call{value: nextPrice}("");
+
+            if (!treasurySuccess || !tokenSuccess || !lastSuccess) {
+                revert ErrCall();
+            }
+
+            IERC20(token).mint(lastController, timeDifference);
+        }
+    }
 }

--- a/src/Harberger.sol
+++ b/src/Harberger.sol
@@ -34,10 +34,10 @@ struct Perwei {
 library Harberger {
     function getNextPrice(
         Perwei memory perwei,
-        uint256 secondsDelta,
+        uint256 timeDifference,
         uint256 collateral
     ) internal pure returns (uint256, uint256) {
-        uint256 taxes = taxPerSecond(perwei, secondsDelta, collateral);
+        uint256 taxes = taxPerSecond(perwei, timeDifference, collateral);
 
         if (collateral < taxes) {
             return (0, collateral);
@@ -48,12 +48,12 @@ library Harberger {
 
     function taxPerSecond(
         Perwei memory perwei,
-        uint256 secondsDelta,
+        uint256 timeDifference,
         uint256 collateral
     ) internal pure returns (uint256) {
         return
             FixedPointMathLib.fdiv(
-                collateral * secondsDelta * perwei.numerator,
+                collateral * timeDifference * perwei.numerator,
                 perwei.denominator * FixedPointMathLib.WAD,
                 FixedPointMathLib.WAD
             );

--- a/src/Harberger.sol
+++ b/src/Harberger.sol
@@ -27,35 +27,35 @@ https://en.wikipedia.org/w/index.php?title=Parts-per_notation&oldid=1068959843
 
 */
 struct Perwei {
-  uint256 numerator;
-  uint256 denominator;
+    uint256 numerator;
+    uint256 denominator;
 }
 
 library Harberger {
-  function getNextPrice(
-    Perwei memory perwei,
-    uint256 blockDiff,
-    uint256 collateral
-  ) internal pure returns (uint256, uint256) {
-    uint256 taxes = taxPerBlock(perwei, blockDiff, collateral);
-    int256 diff = int256(collateral) - int256(taxes);
+    function getNextPrice(
+        Perwei memory perwei,
+        uint256 blockDiff,
+        uint256 collateral
+    ) internal pure returns (uint256, uint256) {
+        uint256 taxes = taxPerBlock(perwei, blockDiff, collateral);
 
-    if (diff <= 0) {
-      return (0, collateral);
-    } else {
-      return (uint256(diff), taxes);
+        if (collateral < taxes) {
+            return (0, collateral);
+        } else {
+            return (collateral - taxes, taxes);
+        }
     }
-  }
 
-  function taxPerBlock(
-    Perwei memory perwei,
-    uint256 blockDiff,
-    uint256 collateral
-  ) internal pure returns (uint256) {
-    return FixedPointMathLib.fdiv(
-      collateral * blockDiff * perwei.numerator,
-      perwei.denominator * FixedPointMathLib.WAD,
-      FixedPointMathLib.WAD
-    );
-  }
+    function taxPerBlock(
+        Perwei memory perwei,
+        uint256 blockDiff,
+        uint256 collateral
+    ) internal pure returns (uint256) {
+        return
+            FixedPointMathLib.fdiv(
+                collateral * blockDiff * perwei.numerator,
+                perwei.denominator * FixedPointMathLib.WAD,
+                FixedPointMathLib.WAD
+            );
+    }
 }

--- a/src/Harberger.sol
+++ b/src/Harberger.sol
@@ -27,35 +27,35 @@ https://en.wikipedia.org/w/index.php?title=Parts-per_notation&oldid=1068959843
 
 */
 struct Perwei {
-    uint256 numerator;
-    uint256 denominator;
+  uint256 numerator;
+  uint256 denominator;
 }
 
 library Harberger {
-    function getNextPrice(
-        Perwei memory perwei,
-        uint256 timeDifference,
-        uint256 collateral
-    ) internal pure returns (uint256, uint256) {
-        uint256 taxes = taxPerSecond(perwei, timeDifference, collateral);
+  function getNextPrice(
+    Perwei memory perwei,
+    uint256 timeDifference,
+    uint256 collateral
+  ) internal pure returns (uint256, uint256) {
+    uint256 taxes = taxPerSecond(perwei, timeDifference, collateral);
 
-        if (collateral < taxes) {
-            return (0, collateral);
-        } else {
-            return (collateral - taxes, taxes);
-        }
+    if (collateral < taxes) {
+      return (0, collateral);
+    } else {
+      return (collateral - taxes, taxes);
     }
+  }
 
-    function taxPerSecond(
-        Perwei memory perwei,
-        uint256 timeDifference,
-        uint256 collateral
-    ) internal pure returns (uint256) {
-        return
-            FixedPointMathLib.fdiv(
-                collateral * timeDifference * perwei.numerator,
-                perwei.denominator * FixedPointMathLib.WAD,
-                FixedPointMathLib.WAD
-            );
-    }
+  function taxPerSecond(
+    Perwei memory perwei,
+    uint256 timeDifference,
+    uint256 collateral
+  ) internal pure returns (uint256) {
+    return
+      FixedPointMathLib.fdiv(
+        collateral * timeDifference * perwei.numerator,
+        perwei.denominator * FixedPointMathLib.WAD,
+        FixedPointMathLib.WAD
+      );
+  }
 }

--- a/src/Harberger.sol
+++ b/src/Harberger.sol
@@ -34,10 +34,10 @@ struct Perwei {
 library Harberger {
     function getNextPrice(
         Perwei memory perwei,
-        uint256 blockDiff,
+        uint256 secondsDelta,
         uint256 collateral
     ) internal pure returns (uint256, uint256) {
-        uint256 taxes = taxPerBlock(perwei, blockDiff, collateral);
+        uint256 taxes = taxPerSecond(perwei, secondsDelta, collateral);
 
         if (collateral < taxes) {
             return (0, collateral);
@@ -46,14 +46,14 @@ library Harberger {
         }
     }
 
-    function taxPerBlock(
+    function taxPerSecond(
         Perwei memory perwei,
-        uint256 blockDiff,
+        uint256 secondsDelta,
         uint256 collateral
     ) internal pure returns (uint256) {
         return
             FixedPointMathLib.fdiv(
-                collateral * blockDiff * perwei.numerator,
+                collateral * secondsDelta * perwei.numerator,
                 perwei.denominator * FixedPointMathLib.WAD,
                 FixedPointMathLib.WAD
             );

--- a/src/Seconds.sol
+++ b/src/Seconds.sol
@@ -23,9 +23,7 @@ contract Seconds is ERC20, Owned(msg.sender), ReentrancyGuard {
     authority = _newAuthority;
   }
 
-  function share(
-    uint256 _value
-  ) public view returns(uint256 balance) {
+  function share(uint256 _value) public view returns (uint256 balance) {
     uint256 amount = FixedPointMathLib.fdiv(
       _value * address(this).balance,
       totalSupply * FixedPointMathLib.WAD,
@@ -45,7 +43,7 @@ contract Seconds is ERC20, Owned(msg.sender), ReentrancyGuard {
 
     _burn(msg.sender, _value);
 
-    (bool result,) = msg.sender.call{value: amount}("");
+    (bool result, ) = msg.sender.call{value: amount}("");
     if (!result) {
       revert ErrCall();
     }


### PR DESCRIPTION
Unfortunately there were some clashes with the formatting. Apart from that, you can see the main changes at these commits:

- daac8c3d4e4baec5d9a593090d03f853b00573f4: instead of casting to `int` I suggest this other approach
- b1f9d1c133d64c2b42e8b957c1eef9ba28bc05d7: the function calculate taxes based on the seconds passed so I change its name
- 3a3893b7e2d03641d1c5e6ace6b53acf5bef71cf: the check here was missing

I also added a `.prettierrc` config file so new contributors are aligned with the formatting. Feel free to remove it if you don't want it.